### PR TITLE
Added file EmdDim.lean and updated readme

### DIFF
--- a/EmbDim.lean
+++ b/EmbDim.lean
@@ -1,0 +1,41 @@
+import Mathlib
+
+local notation3:max "max" A => (IsLocalRing.maximalIdeal A)
+
+open IsLocalRing
+
+-- This is proving that a (nontrivial) quotient of a local ring is a local ring
+instance {R : Type*} [CommRing R] [IsLocalRing R] {I : Ideal R} [Nontrivial (R ⧸ I)] :
+    IsLocalRing (R ⧸ I) := IsLocalRing.of_surjective' (Ideal.Quotient.mk I) Ideal.Quotient.mk_surjective
+
+-- Ideal.Quotient.mk is the map from R to R/I
+-- This theorem is saying that the preimage (Ideal.comap) of the maximal ideal in R/I is the maximal
+-- ideal in R.
+theorem maxQuot {R : Type*} [CommRing R] [IsLocalRing R] {I : Ideal R} [Nontrivial (R ⧸ I)] :
+    Ideal.comap (Ideal.Quotient.mk I) (max (R ⧸ I)) = (max R) := by
+  have : Ideal.IsMaximal (Ideal.comap (Ideal.Quotient.mk I) (max (R ⧸ I))) :=
+    Ideal.comap_isMaximal_of_surjective (Ideal.Quotient.mk I) Ideal.Quotient.mk_surjective
+  exact IsLocalRing.eq_maximalIdeal this
+
+-- This theorem is saying that the image (Ideal.map) of the maximal ideal in R is the maximal
+-- ideal in R/I.
+theorem maxQuot' {R : Type*} [CommRing R] [IsLocalRing R] {I : Ideal R} [Nontrivial (R ⧸ I)] :
+    Ideal.map (Ideal.Quotient.mk I) (max R) = (max (R ⧸ I)) := by
+  have := Ideal.map_comap_of_surjective (Ideal.Quotient.mk I) Ideal.Quotient.mk_surjective (max (R ⧸ I))
+  rw[maxQuot] at this
+  exact this
+
+-- The embedding dimension of a local ring defined to be the dimension of m/m^2
+noncomputable def IsLocalRing.EmbDim (R : Type*) [CommRing R] [IsLocalRing R] [IsNoetherianRing R] : ℕ :=
+    Module.finrank (ResidueField R) (CotangentSpace R)
+
+-- This is essentially Nakayama's Lemma in the special case of a Local Ring
+#check IsLocalRing.CotangentSpace.span_image_eq_top_iff
+
+theorem IsLocalRing.Embdim_eq_spanFinrank_maximal_ideal (R : Type*) [CommRing R] [IsLocalRing R] [IsNoetherianRing R] :
+    IsLocalRing.EmbDim R = (max R).spanFinrank := sorry
+
+theorem IsLocalRing.Embdim_Quotient_span_singleton
+{R : Type*} {x : R} [CommRing R] [IsLocalRing R] [IsNoetherianRing R]
+[Nontrivial (R ⧸ Ideal.span {x})] (hx1 : x ∈ (max R)) (hx2 : x ∉ ((max R)^2)) :
+    (IsLocalRing.EmbDim R) = IsLocalRing.EmbDim (R ⧸ Ideal.span {x}) + 1 := sorry

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 This is a UW community formalization project centered on formalizing regular local rings.  
 
 Goal 1: Prove the undone theorems in EmdDim.lean.
+
 Goal 2: Regular local rings are integral domains.
-Goal 3: Regular local rings are Cohen Macaulay
-Goal 4: 1 dimensional Regular local rings are PID's
+
+Goal 3: Regular local rings are Cohen Macaulay.
+
+Goal 4: 1 dimensional Regular local rings are PIDs.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 This is a UW community formalization project centered on formalizing regular local rings.  
 
-Goal 1: Regular local rings are integral domains.
+Goal 1: Prove the undone theorems in EmdDim.lean.
+Goal 2: Regular local rings are integral domains.
+Goal 3: Regular local rings are Cohen Macaulay
+Goal 4: 1 dimensional Regular local rings are PID's


### PR DESCRIPTION
I have finished the proof that regular local rings are domains up to two statements. The file is getting kind of long/messy and I want to clean it up before committing it so I put the two statements that I need in a separate file called EmdDim.lean to make it easier for someone to work on. The two statements are:

1. The embedding dimension (dim m/m^2) of a local ring is the same as the minimal number of generators of m.
2. If x is an element of m that is not in m^2 then the embedding dimension of R/x is the embedding dimension of R minus 1.