### PR TITLE
Many updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a UW community formalization project centered on formalizing regular loc
 
 Goal 1: Prove the undone theorems in EmdDim.lean.
 
-Goal 2: Regular local rings are integral domains.
+~~Goal 2: Regular local rings are integral domains.~~
 
 Goal 3: Regular local rings are Cohen Macaulay.
 

--- a/RegularLocalRings/EmbDim.lean
+++ b/RegularLocalRings/EmbDim.lean
@@ -1,0 +1,41 @@
+import Mathlib
+
+local notation3:max "max" A => (IsLocalRing.maximalIdeal A)
+
+open IsLocalRing
+
+-- This is proving that a (nontrivial) quotient of a local ring is a local ring
+instance {R : Type*} [CommRing R] [IsLocalRing R] {I : Ideal R} [Nontrivial (R ⧸ I)] :
+    IsLocalRing (R ⧸ I) := IsLocalRing.of_surjective' (Ideal.Quotient.mk I) Ideal.Quotient.mk_surjective
+
+-- Ideal.Quotient.mk is the map from R to R/I
+-- This theorem is saying that the preimage (Ideal.comap) of the maximal ideal in R/I is the maximal
+-- ideal in R.
+theorem maxQuot {R : Type*} [CommRing R] [IsLocalRing R] {I : Ideal R} [Nontrivial (R ⧸ I)] :
+    Ideal.comap (Ideal.Quotient.mk I) (max (R ⧸ I)) = (max R) := by
+  have : Ideal.IsMaximal (Ideal.comap (Ideal.Quotient.mk I) (max (R ⧸ I))) :=
+    Ideal.comap_isMaximal_of_surjective (Ideal.Quotient.mk I) Ideal.Quotient.mk_surjective
+  exact IsLocalRing.eq_maximalIdeal this
+
+-- This theorem is saying that the image (Ideal.map) of the maximal ideal in R is the maximal
+-- ideal in R/I.
+theorem maxQuot' {R : Type*} [CommRing R] [IsLocalRing R] {I : Ideal R} [Nontrivial (R ⧸ I)] :
+    Ideal.map (Ideal.Quotient.mk I) (max R) = (max (R ⧸ I)) := by
+  have := Ideal.map_comap_of_surjective (Ideal.Quotient.mk I) Ideal.Quotient.mk_surjective (max (R ⧸ I))
+  rw[maxQuot] at this
+  exact this
+
+-- The embedding dimension of a local ring defined to be the dimension of m/m^2
+noncomputable def IsLocalRing.EmbDim (R : Type*) [CommRing R] [IsLocalRing R] [IsNoetherianRing R] : ℕ :=
+    Module.finrank (ResidueField R) (CotangentSpace R)
+
+-- This is essentially Nakayama's Lemma in the special case of a Local Ring
+#check IsLocalRing.CotangentSpace.span_image_eq_top_iff
+
+theorem IsLocalRing.Embdim_eq_spanFinrank_maximal_ideal (R : Type*) [CommRing R] [IsLocalRing R] [IsNoetherianRing R] :
+    IsLocalRing.EmbDim R = (max R).spanFinrank := sorry
+
+theorem IsLocalRing.Embdim_Quotient_span_singleton
+{R : Type*} {x : R} [CommRing R] [IsLocalRing R] [IsNoetherianRing R]
+[Nontrivial (R ⧸ Ideal.span {x})] (hx1 : x ∈ (max R)) (hx2 : x ∉ ((max R)^2)) :
+    (IsLocalRing.EmbDim R) = IsLocalRing.EmbDim (R ⧸ Ideal.span {x}) + 1 := sorry

--- a/RegularLocalRings/KrullsHeightTheorem.lean
+++ b/RegularLocalRings/KrullsHeightTheorem.lean
@@ -1,0 +1,11 @@
+import Mathlib
+
+lemma Ideal.height_le_spanRank_toENat_of_mem_minimal_primes {R : Type*} [CommRing R] [IsNoetherianRing R]
+    (I : Ideal R) (p : Ideal R) (hp : p ∈ I.minimalPrimes) :
+    p.height ≤ I.spanRank.toENat := sorry
+
+lemma Ideal.height_le_spanRank_toENat {R : Type*} [CommRing R] [IsNoetherianRing R] (I : Ideal R) (hI : I ≠ ⊤) :
+    I.height ≤ I.spanRank.toENat := sorry
+
+lemma Ideal.height_le_spanFinrank {R : Type*} [CommRing R] [IsNoetherianRing R] (I : Ideal R) (hI : I ≠ ⊤) :
+    I.height ≤ I.spanFinrank := sorry

--- a/RegularLocalRings/LocalRingDimension.lean
+++ b/RegularLocalRings/LocalRingDimension.lean
@@ -1,6 +1,6 @@
 import Mathlib
-import «LeanMath».KrullsHeightTheorem
-import «LeanMath».EmbDim
+import «RegularLocalRings».KrullsHeightTheorem
+import «RegularLocalRings».EmbDim
 
 local notation3:max "max" A => (IsLocalRing.maximalIdeal A)
 

--- a/RegularLocalRings/LocalRingDimension.lean
+++ b/RegularLocalRings/LocalRingDimension.lean
@@ -1,0 +1,399 @@
+import Mathlib
+import «LeanMath».KrullsHeightTheorem
+import «LeanMath».EmbDim
+
+local notation3:max "max" A => (IsLocalRing.maximalIdeal A)
+
+variable {R : Type*} [CommRing R]
+
+-- The Krull dimension of R cast as a natural number. If R has infinite Krull dimension or is the zero ring then
+-- finRingKrullDim R = 0
+noncomputable def finRingKrullDim (R : Type*) [CommRing R] : ℕ := ENat.toNat (WithBot.unbotD 0 (ringKrullDim R))
+
+open Ideal
+
+-- Instance that a noetherian local ring has finite Krull dimension. This follows from Krull's height
+-- theorem
+instance {R : Type*} [CommRing R] [IsLocalRing R] [IsNoetherianRing R] :
+    FiniteRingKrullDim R := by
+  apply finiteRingKrullDim_iff_ne_bot_and_top.mpr
+
+  constructor
+  have KDge0 := @ringKrullDim_nonneg_of_nontrivial R _ _
+  by_contra hc
+  rw[hc] at KDge0
+  contradiction
+
+  rw[← IsLocalRing.maximalIdeal_height_eq_ringKrullDim]
+  have finHeight := Ideal.height_le_spanFinrank (max R) Ideal.IsPrime.ne_top'
+  have : Submodule.spanFinrank (max R) < (⊤ : ℕ∞) := ENat.coe_lt_top (Submodule.spanFinrank max R)
+
+  by_contra hc
+  have : (max R).height < ⊤ := lt_of_le_of_lt finHeight this
+  have : (max R).height < (⊤ : WithBot ℕ∞) := WithBot.coe_lt_coe.mpr this
+  rw[hc] at this
+  contradiction
+
+
+-- Coersion to help when coparing ringKrullDim and finRingKrullDim
+lemma NatCast_WithBot_le (n m : ℕ) (h : (n : WithBot ℕ∞) ≤ m) : n ≤ m := by
+  simp at h ⊢
+  exact h
+
+
+-- If R has finite Krull dimension then ringKrullDim R = finRingKrullDim R
+theorem finRingKrullDim_ringKrullDim (R : Type*) [CommRing R] [FiniteRingKrullDim R] :
+    ringKrullDim R = finRingKrullDim R := by
+  have hn := (finiteRingKrullDim_iff_ne_bot_and_top.mp ‹_›).left
+  have hm := (finiteRingKrullDim_iff_ne_bot_and_top.mp ‹_›).right
+
+  let n : ℕ∞ := WithBot.unbot (ringKrullDim R) hn
+  have h1 : ringKrullDim R = n := (WithBot.unbot_eq_iff hn).mp rfl
+  have h3 : WithBot.unbotD 0 (ringKrullDim R) = (ringKrullDim R) := by
+    rw[h1]
+    rfl
+  have : WithBot.unbotD 0 (ringKrullDim R) ≠ ⊤ := by
+    by_contra hc
+    obtain hl|hr := (@WithBot.unbotD_eq_iff ℕ∞ 0 ⊤ (ringKrullDim R)).mp hc
+    exact hm hl
+    exact hn hr.left
+
+  have : ENat.toNat (WithBot.unbotD 0 (ringKrullDim R)) = WithBot.unbotD 0 (ringKrullDim R) := ENat.coe_toNat this
+  unfold finRingKrullDim
+  nth_rw 1 [← h3]
+  nth_rw 1 [← this]
+  rfl
+
+
+theorem finRingKrullDim_mono (R : Type*) [CommRing R] [FiniteRingKrullDim R] (n : ℕ) :
+    ringKrullDim R ≤ n ↔ finRingKrullDim R ≤ n := by
+  rw[finRingKrullDim_ringKrullDim]
+  exact Nat.cast_le
+
+
+-- If I is prime and contained in a minimal prime p then I=p
+lemma le_minimalPrimes
+{R : Type*} [CommRing R] {I : Ideal R} [I.IsPrime] {P : Ideal R} (hP : P ∈ minimalPrimes R) (hI : I ≤ P) :
+    I = P := by
+  rw[minimalPrimes_eq_minimals] at hP
+  obtain ⟨hP1, hP2⟩ := hP
+  have := hP2 ‹_› hI
+  exact le_antisymm_iff.mpr ⟨hI, this⟩
+
+
+-- If x is not contained in any minimal prime of R then the Krull Dim of R/x is strictly less
+-- than the Krull Dim of R
+-- This proof is modified from ringKrullDim_quotient_succ_le_of_nonZeroDivisor
+lemma ringKrullDim_quotient_succ_le_of_not_in_minimalPrimes
+{R : Type*} [CommRing R] {r : R} (hr : ∀ p ∈ minimalPrimes R, r ∉ p) :
+    ringKrullDim (R ⧸ Ideal.span {r}) + 1 ≤ ringKrullDim R := by
+  by_cases hr' : Ideal.span {r} = ⊤
+  · rw [hr', ringKrullDim_eq_bot_of_subsingleton]
+    simp
+  have : Nonempty (PrimeSpectrum.zeroLocus (R := R) (Ideal.span {r})) := by
+    rwa [Set.nonempty_coe_sort, Set.nonempty_iff_ne_empty, ne_eq,
+      PrimeSpectrum.zeroLocus_empty_iff_eq_top]
+  have := Ideal.Quotient.nontrivial hr'
+  have := (Ideal.Quotient.mk (Ideal.span {r})).domain_nontrivial
+  rw [ringKrullDim_quotient, Order.krullDim_eq_iSup_length, ringKrullDim,
+    Order.krullDim_eq_iSup_length, ← WithBot.coe_one, ← WithBot.coe_add,
+    ENat.iSup_add, WithBot.coe_le_coe, iSup_le_iff]
+  intro l
+  obtain ⟨p, hp, hp'⟩ := Ideal.exists_minimalPrimes_le (J := l.head.1.asIdeal) bot_le
+  let p' : PrimeSpectrum R := ⟨p, hp.1.1⟩
+  have hp' : p' < l.head := by
+    let q := l.head.val
+    have : (span {r} : Set R) ⊆ q.asIdeal := Subtype.coe_prop l.head
+
+    refine lt_of_le_of_ne hp' ?_
+    by_contra hc
+    have : r ∈ (@Subtype.val (PrimeSpectrum R) (fun x ↦ x ∈ PrimeSpectrum.zeroLocus ↑(span {r})) (RelSeries.head l)).asIdeal := by
+      have : r ∈ span {r} := mem_span_singleton_self r
+      (expose_names; exact this_4 this)
+    rw[← hc] at this
+    exact hr p hp this
+  refine le_trans ?_ (le_iSup _ ((l.map Subtype.val (fun _ _ ↦ id)).cons p' hp'))
+  simp
+
+
+-- If Dim R ≥ 1 then there is an element x of m that is not in any minimal prime of R.
+-- This proof could be made more general and does not really require that R is local.
+lemma IsLocalRing.one_le_ringKrullDim_element_notin_minimalPrimes
+    [IsLocalRing R] [IsNoetherianRing R] (hKD : 1 ≤ ringKrullDim R) :
+    ∃ x ∈ (max R), ∀ p ∈ minimalPrimes R, x ∉ p := by
+  by_contra hc
+  push_neg at hc
+
+  let S := Set.Finite.toFinset (minimalPrimes.finite_of_isNoetherianRing R)
+  have Sdef : (S : Set (Ideal R)) = minimalPrimes R := by
+    exact Set.Finite.coe_toFinset (minimalPrimes.finite_of_isNoetherianRing R)
+
+  have hp : ∀ i ∈ S, i ≠ ⊥ → i ≠ ⊥ → i.IsPrime := by
+    intro i hi _ _
+    have : i ∈ minimalPrimes R := by
+      simp_all only [mem_maximalIdeal, mem_nonunits_iff, Set.Finite.coe_toFinset, Set.Finite.mem_toFinset, S]
+    exact minimalPrimes_isPrime this
+
+  have maxinmin : ∃ i ∈ S, (max R) ≤ i := by
+    apply (@Ideal.subset_union_prime (Ideal R) R _ S id ⊥ ⊥ hp (max R)).mp
+    intro x hx
+    obtain ⟨p, hp1, hp2⟩ := hc x hx
+    refine Set.mem_iUnion₂.mpr ?_
+    use p
+    have : p ∈ S := (Set.Finite.mem_toFinset (minimalPrimes.finite_of_isNoetherianRing R)).mpr hp1
+    use this
+    exact hp2
+
+  obtain ⟨p , hp1, hp2⟩ := maxinmin
+  have hp3 : p ∈ minimalPrimes R := by
+    simp_all only [mem_maximalIdeal, mem_nonunits_iff, Set.Finite.coe_toFinset, Set.Finite.mem_toFinset, S]
+
+  have maxp := le_antisymm_iff.mpr
+    ⟨hp2 , IsLocalRing.le_maximalIdeal (IsPrime.ne_top (minimalPrimes_isPrime hp3))⟩
+
+  rw[← maxp] at hp3
+
+  have : Ring.KrullDimLE 0 R := by
+    refine Ring.KrullDimLE.mk₀ ?_
+    intro I hI
+    have : I ≤ (max R) := IsLocalRing.le_maximalIdeal (Ideal.IsPrime.ne_top hI)
+    have := le_minimalPrimes hp3 this
+    exact (isMaximal_iff R).mpr this
+
+  have : ringKrullDim R = 0 := ringKrullDimZero_iff_ringKrullDim_eq_zero.mp this
+
+  rw[this] at hKD
+  contradiction
+
+
+theorem Min_Prime_over_ringKrullDim_Ind :
+    ∀ (n : ℕ) (R : Type*) [CommRing R] [IsLocalRing R] [IsNoetherianRing R], finRingKrullDim R = n → ∃ s : Finset R,
+    s.card ≤ finRingKrullDim R ∧ (max R) ∈ (Ideal.span s).minimalPrimes := by
+  intro N
+
+  refine Nat.strong_induction_on N ?_
+  intro n
+  by_cases hn : n = 0
+
+  intro _ R _ _ _ KD
+  rw[hn] at KD
+  have KD0 : ringKrullDim R = 0 := by
+    rw[finRingKrullDim_ringKrullDim R]
+    exact congrArg Nat.cast KD
+  use ∅
+  have : (∅ : Finset R).card = 0 := rfl
+  rw[this]
+  rw[KD]
+  constructor
+  exact Nat.zero_le 0
+  have _ : Ring.KrullDimLE 0 R := ringKrullDimZero_iff_ringKrullDim_eq_zero.mpr KD0
+  apply Ring.KrullDimLE.mem_minimalPrimes_iff_le_of_isPrime.mpr
+  simp only [Finset.coe_empty, span_empty, bot_le]
+
+  intro ih R _ _ _ hKD
+  push_neg at hn
+  have : n ≥ 1 := Nat.one_le_iff_ne_zero.mpr hn
+  have : finRingKrullDim R ≥ 1 := by simp_all only [ge_iff_le, le_add_iff_nonneg_left, zero_le]
+  have : ringKrullDim R ≥ 1 := by
+    rw[finRingKrullDim_ringKrullDim]
+    exact Nat.one_le_cast.mpr this
+
+  obtain ⟨x, hx1, hx2⟩ := IsLocalRing.one_le_ringKrullDim_element_notin_minimalPrimes this
+
+  have quotDim := ringKrullDim_quotient_succ_le_of_not_in_minimalPrimes hx2
+  have _ : Nontrivial (R ⧸ (Ideal.span {x})) := Ideal.Quotient.nontrivial (Ideal.span_singleton_ne_top hx1)
+  rw[finRingKrullDim_ringKrullDim R, finRingKrullDim_ringKrullDim (R ⧸ span {x})] at quotDim
+  have : (finRingKrullDim (R ⧸ span {x})) + 1 ≤ (finRingKrullDim R) := by
+    apply NatCast_WithBot_le
+    exact quotDim
+
+  have i : (finRingKrullDim (R ⧸ span {x})) < n := by linarith
+
+  obtain ⟨s, hs1, hs2⟩ := ih (finRingKrullDim (R ⧸ span {x})) i (R ⧸ span {x}) rfl
+
+  let q : (R ⧸ (Ideal.span {x})) ↪ R := {
+    toFun := Quotient.out
+    inj' := Quotient.out_injective
+  }
+
+  let S : Finset R := Finset.map q s
+  have Scard : S.card = s.card := Finset.card_map q
+  have hS' : (S ∪ {x} : Set R).Finite := Set.toFinite (↑S ∪ {x})
+  have ncard := Set.ncard_union_le S {x}
+  rw[Set.ncard_singleton x, Set.ncard_coe_Finset] at ncard
+  let S' := Set.Finite.toFinset hS'
+
+  have cardsle : S'.card ≤ S.card + 1 := by
+    rw[← Set.ncard_coe_Finset]
+    have : (S' : Set R).ncard = (S ∪ {x} : Set R).ncard := by
+      rw[Set.Finite.coe_toFinset hS']
+    linarith
+
+  have im : Ideal.map (Ideal.Quotient.mk (Ideal.span {x})) (Ideal.span S) = Ideal.span s := by
+    have imS : (Ideal.Quotient.mk (Ideal.span {x}))'' S = s := by
+      simp_all only [Finset.card_map, Finset.coe_map, Function.Embedding.coeFn_mk, S, q]
+      ext x_1 : 1
+      simp_all only [Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and, Ideal.Quotient.mk_out, exists_eq_right]
+    rw[Ideal.map_span, imS]
+
+  have comapmap := Ideal.comap_map_of_surjective' (Ideal.Quotient.mk (Ideal.span {x})) Ideal.Quotient.mk_surjective (Ideal.span S)
+
+  rw[im] at comapmap
+  rw[Ideal.mk_ker] at comapmap
+  have spanunion : Ideal.span (↑S ∪ {x}) = Ideal.span S ⊔ Ideal.span {x} := @Submodule.span_union R R _ _ _ S {x}
+
+  have smspan : span S' = span (S ∪ {x}) := by simp_all only [Finset.card_map, Finset.coe_map, Function.Embedding.coeFn_mk,
+    Set.union_singleton, submodule_span_eq, Set.Finite.subset_toFinset, Set.subset_insert, Set.Finite.coe_toFinset, q,
+    S, S']
+
+  rw[spanunion, ← comapmap] at smspan
+
+  have comapMinPrimes := @Ideal.comap_minimalPrimes_eq_of_surjective R (R ⧸ span {x}) _ _
+    (Ideal.Quotient.mk (span {x})) Ideal.Quotient.mk_surjective (span s)
+
+  rw[← smspan] at comapMinPrimes
+
+  have maxmin : (max R) ∈ (span S').minimalPrimes := by
+    have : (max R) = comap (Ideal.Quotient.mk (span {x})) (max (R ⧸ span {x})) := Eq.symm maxQuot
+    have : (max R) ∈ comap (Ideal.Quotient.mk (span {x})) '' (span ↑s).minimalPrimes := by
+      simp_all only [Finset.card_map, Finset.coe_map, Function.Embedding.coeFn_mk, Set.union_singleton,
+        Set.encard_singleton, Set.Finite.coe_toFinset, Set.mem_image, S', S, q]
+      apply Exists.intro
+      · apply And.intro
+        on_goal 2 => {rfl
+        }
+        · simp_all only [S', S, q]
+
+    rw[← comapMinPrimes] at this
+    exact this
+
+  use S'
+  refine ⟨?_, maxmin⟩
+  linarith
+
+
+-- There is an ideal generated by at most Dim R elements that m is minimal over.
+-- In other words, there is an m primary ideal generated by Dim R elements.
+theorem Min_Prime_over_ringKrullDim (R : Type*) [CommRing R] [IsLocalRing R] [IsNoetherianRing R] :
+    ∃ s : Finset R, s.card ≤ finRingKrullDim R ∧ (max R) ∈ (Ideal.span s).minimalPrimes :=
+  Min_Prime_over_ringKrullDim_Ind (finRingKrullDim R) R rfl
+
+
+-- If x ∈ m then Dim R/x ≥ Dim R - 1. I.e. the dimension of the quotient drops by at most 1. Note that
+-- this is not true non-local Noetherian rings in general
+theorem IsLocalRing.Quotient_singleton_ringKrullDim [IsLocalRing R] [IsNoetherianRing R] (x : R)
+[Nontrivial (R ⧸ (Ideal.span {x}))] : ringKrullDim R ≤ ringKrullDim (R ⧸ (Ideal.span {x})) + 1 := by
+
+  obtain ⟨s , hs1 , hs2⟩ := Min_Prime_over_ringKrullDim (R ⧸ (Ideal.span {x}))
+
+  let q : (R ⧸ (Ideal.span {x})) ↪ R := {
+    toFun := Quotient.out
+    inj' := Quotient.out_injective
+  }
+
+  let S : Finset R := Finset.map q s
+
+  have Scard : S.card = s.card := Finset.card_map q
+  have hS' : (S ∪ {x} : Set R).Finite := Set.toFinite (↑S ∪ {x})
+  have ncard := Set.ncard_union_le S {x}
+  rw[Set.ncard_singleton x, Set.ncard_coe_Finset] at ncard
+  let S' := Set.Finite.toFinset hS'
+
+  have cardsle : S'.card ≤ S.card + 1 := by
+    rw[← Set.ncard_coe_Finset]
+    have : (S' : Set R).ncard = (S ∪ {x} : Set R).ncard := by
+      rw[Set.Finite.coe_toFinset hS']
+    linarith
+
+  have im : Ideal.map (Ideal.Quotient.mk (Ideal.span {x})) (Ideal.span S) = Ideal.span s := by
+    have imS : (Ideal.Quotient.mk (Ideal.span {x}))'' S = s := by
+      simp_all only [Finset.card_map, Finset.coe_map, Function.Embedding.coeFn_mk, S, q]
+      ext x_1 : 1
+      simp_all only [Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and, Ideal.Quotient.mk_out, exists_eq_right]
+    rw[Ideal.map_span, imS]
+
+  have comapmap := Ideal.comap_map_of_surjective' (Ideal.Quotient.mk (Ideal.span {x})) Ideal.Quotient.mk_surjective (Ideal.span S)
+
+  rw[im] at comapmap
+  rw[Ideal.mk_ker] at comapmap
+  have spanunion : Ideal.span (↑S ∪ {x}) = Ideal.span S ⊔ Ideal.span {x} := @Submodule.span_union R R _ _ _ S {x}
+
+  have smspan : span S' = span (S ∪ {x}) := by simp_all only [Finset.card_map, Finset.coe_map, Function.Embedding.coeFn_mk,
+    Set.union_singleton, submodule_span_eq, Set.Finite.subset_toFinset, Set.subset_insert, Set.Finite.coe_toFinset, q,
+    S, S']
+
+  rw[spanunion, ← comapmap] at smspan
+
+  have comapMinPrimes := @Ideal.comap_minimalPrimes_eq_of_surjective R (R ⧸ span {x}) _ _
+    (Ideal.Quotient.mk (span {x})) Ideal.Quotient.mk_surjective (span s)
+
+  rw[← smspan] at comapMinPrimes
+
+  have maxmin : (max R) ∈ (span S').minimalPrimes := by
+    have : (max R) = comap (Ideal.Quotient.mk (span {x})) (max (R ⧸ span {x})) := Eq.symm maxQuot
+    have : (max R) ∈ comap (Ideal.Quotient.mk (span {x})) '' (span ↑s).minimalPrimes := by
+      simp_all only [Finset.card_map, Finset.coe_map, Function.Embedding.coeFn_mk, Set.union_singleton,
+        Set.encard_singleton, Set.Finite.coe_toFinset, Set.mem_image, S', S, q]
+      apply Exists.intro
+      · apply And.intro
+        on_goal 2 => {rfl
+        }
+        · simp_all only [S', S, q]
+
+    rw[← comapMinPrimes] at this
+    exact this
+
+  have KDRle := (Ideal.height_le_spanRank_toENat_of_mem_minimal_primes (span (S' : Set R)) (max R)) maxmin
+
+  have maxKDR : (max R).height = ringKrullDim R := maximalIdeal_height_eq_ringKrullDim
+
+  have spanrk := @Submodule.spanFinrank_span_le_ncard_of_finite R R _ _ _ S' (Finset.finite_toSet S')
+  rw[Set.ncard_coe_Finset S'] at spanrk
+
+  have g : (span (S' : Set R)).FG := by
+    use S'
+
+  rw[Submodule.fg_iff_spanRank_eq_spanFinrank.mpr g] at KDRle
+
+  simp at KDRle
+
+  have a := ENat.coe_le_coe.mpr spanrk
+
+  have maxleK : (max R).height ≤ finRingKrullDim (R ⧸ span {x}) + 1 := by
+    have a : (max R).height ≤ S'.card := Preorder.le_trans (max R).height (span (S' : Set R)).spanFinrank S'.card KDRle a
+    have b : S'.card ≤ finRingKrullDim (R ⧸ span {x}) + 1 := by linarith
+    have c : (S'.card : ℕ∞) ≤ finRingKrullDim (R ⧸ span {x}) + 1 := ENat.coe_le_coe.mpr b
+    exact Preorder.le_trans (max R).height (↑S'.card) (↑(finRingKrullDim (R ⧸ span {x})) + 1) a c
+
+  have al : ((max R).height : WithBot ℕ∞) ≤ finRingKrullDim (R ⧸ span {x}) + 1 := (WithBot.coe_le rfl).mpr maxleK
+
+  rw[maxKDR, ← finRingKrullDim_ringKrullDim (R ⧸ span {x})] at al
+
+  exact al
+
+
+-- If x ∈ m \ m² then the minimal number of generators of m/x is the minimal number of generators for
+-- m minus 1.
+theorem IsLocalRing.Quotient_span_singleton_Submodule.spanFinrank
+[IsLocalRing R] [IsNoetherianRing R] (x : R) [Nontrivial (R ⧸ (Ideal.span {x}))] (hx1 : x ∈ (max R)) (hx2 : x ∉ (max R)^2) :
+    Submodule.spanFinrank (max (R ⧸ Ideal.span {x})) + 1 = Submodule.spanFinrank (max R) := by
+  rw[← IsLocalRing.Embdim_eq_spanFinrank_maximal_ideal R, ← IsLocalRing.Embdim_eq_spanFinrank_maximal_ideal (R ⧸ Ideal.span {x})]
+  exact Eq.symm (IsLocalRing.Embdim_Quotient_span_singleton hx1 hx2)
+
+
+-- The minimal number of generators of m is an upper bound on the dimension of R
+theorem IsLocalRing.ringKrullDim_le_spanFinrank (R : Type*) [CommRing R] [IsLocalRing R] [IsNoetherianRing R] :
+    ringKrullDim R ≤ Submodule.spanFinrank (max R) := by
+
+  rw[← maximalIdeal_height_eq_ringKrullDim]
+  have := Ideal.height_le_spanFinrank (max R) Ideal.IsPrime.ne_top'
+  exact (WithBot.coe_le rfl).mpr this
+
+
+-- If x is a non-unit non-zerodivisor then Dim R/x = Dim R - 1
+theorem IsLocalRing.ringKrullDim_quotient_succ_eq_of_nonZeroDivisor
+    {R : Type*} [CommRing R] [IsLocalRing R] [IsNoetherianRing R] {r : R} (hr : r ∈ nonZeroDivisors R) (hr' : ¬IsUnit r) :
+    ringKrullDim (R ⧸ Ideal.span {r}) + 1 = ringKrullDim R :=
+  le_antisymm_iff.mpr ⟨ringKrullDim_quotient_succ_le_of_nonZeroDivisor hr ,
+  @IsLocalRing.Quotient_singleton_ringKrullDim R _ _ _ r
+  (Ideal.Quotient.nontrivial (span_singleton_ne_top hr'))⟩

--- a/RegularLocalRings/Regular_Local_Ring.lean
+++ b/RegularLocalRings/Regular_Local_Ring.lean
@@ -1,0 +1,277 @@
+import Mathlib
+import «LeanMath».LocalRingDimension
+
+
+local notation3:max "max" A => (IsLocalRing.maximalIdeal A)
+
+variable {R : Type*} [CommRing R]
+
+
+-- Definition of a regular local ring. May change later to EmbDim R = ringKrullDim R once
+-- EmbDim.lean is finished
+class IsRegularLocalRing (R : Type*) [CommRing R] : Prop extends IsLocalRing R, IsNoetherianRing R where
+  reg : (max R).spanFinrank = ringKrullDim R
+
+
+-- If x ∈ m \ m² and R is regular, then R/x is regular. This is the most important fact
+-- for inductively proving things about regular local rings
+theorem IsRegularLocalRing.Quotient_span_singleton_IsRegularLocalRing
+[hreg : IsRegularLocalRing R] (x : R) [Nontrivial (R ⧸ (Ideal.span {x}))] (hx1 : x ∈ (max R)) (hx2 : x ∉ (max R)^2) :
+    IsRegularLocalRing (R ⧸ Ideal.span {x}) := by
+  apply IsRegularLocalRing.mk
+
+  refine le_antisymm_iff.mpr ⟨?_, IsLocalRing.ringKrullDim_le_spanFinrank (R ⧸ Ideal.span {x})⟩
+
+  have KDle := IsLocalRing.Quotient_singleton_ringKrullDim x
+  have hh : ((Submodule.spanFinrank max R ⧸ Ideal.span {x}) + 1 : ℕ) ≤ ringKrullDim (R ⧸ Ideal.span {x}) + 1 := by
+    rw[IsLocalRing.Quotient_span_singleton_Submodule.spanFinrank x hx1 hx2]
+    rw[hreg.reg]
+    exact KDle
+
+  have : ((Submodule.spanFinrank max R ⧸ Ideal.span {x}) + 1 : ℕ) = (((Submodule.spanFinrank max R ⧸ Ideal.span {x}) : WithBot ℕ∞) + 1) := rfl
+
+  rw[this] at hh
+  clear this
+  rw[finRingKrullDim_ringKrullDim] at hh
+  rw[finRingKrullDim_ringKrullDim]
+
+  have natle :
+  (Submodule.spanFinrank max R ⧸ Ideal.span {x}) + 1 ≤ (finRingKrullDim (R ⧸ Ideal.span {x})) + 1 :=
+    NatCast_WithBot_le ((Submodule.spanFinrank max R ⧸ Ideal.span {x}) + 1) ((finRingKrullDim (R ⧸ Ideal.span {x})) + 1) hh
+
+  have natle' : (Submodule.spanFinrank max R ⧸ Ideal.span {x}) ≤ (finRingKrullDim (R ⧸ Ideal.span {x})) := Nat.le_of_lt_succ natle
+
+  exact Nat.cast_le.mpr natle'
+
+
+-- Coersion for going between spanRank and spanFinrank for ideals in a noetherian ring.
+lemma IsNoetherianRing.Ideal_spanRank_eq_spanFinrank [IsNoetherianRing R] (I : Ideal R) :
+    I.spanRank = I.spanFinrank :=
+  Submodule.fg_iff_spanRank_eq_spanFinrank.mpr ((isNoetherianRing_iff_ideal_fg R).mp ‹_› I)
+
+
+-- A regular local ring of dimension 0 is a field.
+lemma IsRegularLocalRing.ringKrullDim_zero_IsField
+    (R : Type*) [CommRing R] [hR : IsRegularLocalRing R] (kd0 : ringKrullDim R = 0) :
+    IsField R := by
+
+  rw[← hR.reg] at kd0
+  have hm : Submodule.spanFinrank (max R) = 0 := by simp_all only [Nat.cast_eq_zero]
+  have SPzero : Submodule.spanRank (max R) = 0 := by
+    rw[IsNoetherianRing.Ideal_spanRank_eq_spanFinrank (max R), hm]
+    rfl
+  have mBot := Submodule.spanRank_eq_zero_iff_eq_bot.mp SPzero
+  exact IsLocalRing.isField_iff_maximalIdeal_eq.mpr (id (mBot))
+
+
+-- The key lemma in the proof that regular local rings are domains: If (x) is prime and
+-- not minimal then R is a domain.
+lemma IsLocalRing_IsNoetherianRing_span_singleton_IsPrime_not_minimalPrimes_IsDomain
+{R : Type*} [CommRing R] [IsLocalRing R] [IsNoetherianRing R]
+(x : R) [hx : (Ideal.span {x}).IsPrime] (notMin : ¬Ideal.span {x} ∈ minimalPrimes R) :
+    IsDomain R := by
+
+  have zero_in_x : ⊥ ≤ Ideal.span {x} := bot_le
+  have min_in_x := Ideal.exists_minimalPrimes_le zero_in_x
+  obtain ⟨q , hq1, hq2⟩ := min_in_x
+
+  have x_not_in_q : x ∉ q := by
+    by_contra hx
+    have : Ideal.span {x} ≤ q := (Ideal.span_singleton_le_iff_mem q).mpr hx
+    have := le_antisymm_iff.mpr ⟨hq2, this⟩
+    rw[this] at hq1
+    exact notMin hq1
+
+  have q_in_x_pow : ∀ n : ℕ, q ≤ Ideal.span {x}^n := by
+    intro n
+    induction n with
+    | zero =>
+      rw[Ideal.span_singleton_pow x 0]
+      rw[pow_zero x]
+      rw[Ideal.span_singleton_one]
+      exact fun ⦃x⦄ a ↦ trivial
+
+    | succ n ih =>
+      intro y hy
+      rw[Ideal.span_singleton_pow]
+      rw[Ideal.span_singleton_pow] at ih
+      obtain ⟨r , hr⟩ := Ideal.mem_span_singleton'.mp (ih hy)
+      have qPrime : q.IsPrime := Ideal.minimalPrimes_isPrime hq1
+      have xpow_not_q : x^n ∉ q := by
+        by_contra hxp
+        have := Ideal.IsPrime.mem_of_pow_mem qPrime n hxp
+        contradiction
+
+      rw[← hr] at hy
+      have : r ∈ q := by
+        have := Ideal.IsPrime.mem_or_mem qPrime hy
+        subst hr
+        simp_all only [bot_le, or_false]
+
+      obtain ⟨a , ha⟩ := Ideal.mem_span_singleton'.mp (hq2 this)
+      apply Ideal.mem_span_singleton'.mpr
+      rw[← ha] at hr
+      use a
+      rw[← hr]
+      ring
+
+  have x_not_top : Ideal.span {x} ≠ ⊤ := Ideal.IsPrime.ne_top ‹_›
+
+  have KIT := Ideal.iInf_pow_eq_bot_of_isLocalRing (Ideal.span {x}) ‹_›
+
+  have qZero : q ≤ ⊥ := by
+    intro y hy
+    have hyx : ∀(n : ℕ), y ∈ Ideal.span {x} ^ n := by
+      intro n
+      exact q_in_x_pow n hy
+
+    have := Ideal.mem_iInf.mpr hyx
+    rw[KIT] at this
+    assumption
+
+  have qeqZero : q = ⊥ := (Submodule.eq_bot_iff q).mpr qZero
+  have qPrime : q.IsPrime := Ideal.minimalPrimes_isPrime hq1
+  rw[qeqZero] at qPrime
+  exact IsDomain.of_bot_isPrime R
+
+
+-- The induction used to show that regular local rings are domains.
+theorem IsRegularLocalRing_IsDomain_Induction :
+    ∀(n : ℕ) (R : Type*) [CommRing R] [IsRegularLocalRing R] (_ : Submodule.spanFinrank (max R) = n), IsDomain R := by
+  intro n
+
+  -- We do induction on the dimeinsion of R
+  induction n with
+  | zero =>
+    intro R _ hR hm
+    have : ringKrullDim R = 0 := by
+      rw[← hR.reg]
+      simp only [Nat.cast_eq_zero]
+      exact hm
+    let FS : Field R := IsField.toField (IsRegularLocalRing.ringKrullDim_zero_IsField R this)
+    exact Field.isDomain
+
+  | succ n ih =>
+    intro R _ hR hn
+    by_contra hR_not_Dom
+
+    -- Our goal is to show that max R is the union of (max R)^2 along with the minimal primes of R.
+    have isMinPrime : ∀(x : R), (x ∈ max R) → (x ∉ (max R)^2) → (Ideal.span {x} ∈ minimalPrimes R) := by
+      intro x hx hx2
+
+      have xPrime : (Ideal.span {x}).IsPrime := by
+        apply (Ideal.Quotient.isDomain_iff_prime (Ideal.span {x})).mp
+
+        have _ : Nontrivial (R ⧸ (Ideal.span {x})) := Ideal.Quotient.nontrivial (Ideal.span_singleton_ne_top hx)
+
+
+        have minGenquot : Submodule.spanFinrank (max (R ⧸ (Ideal.span {x}))) = n := by
+          have := IsLocalRing.Quotient_span_singleton_Submodule.spanFinrank x hx hx2
+          simp_all only [Nat.add_left_inj]
+
+        have quotReg : IsRegularLocalRing (R ⧸ (Ideal.span {x})) := IsRegularLocalRing.Quotient_span_singleton_IsRegularLocalRing x hx hx2
+
+        exact ih (R ⧸ (Ideal.span {x})) minGenquot
+
+      by_contra hx3
+
+      exact hR_not_Dom (IsLocalRing_IsNoetherianRing_span_singleton_IsPrime_not_minimalPrimes_IsDomain x hx3)
+
+    clear ih
+
+    let S' := (minimalPrimes R) ∪ {(max R)^2}
+    have sFin : S'.Finite := Set.Finite.union (minimalPrimes.finite_of_isNoetherianRing R) (Set.finite_singleton ((max R) ^ 2))
+
+    let S := Set.Finite.toFinset sFin
+
+    have hp : (∀ i ∈ S, (i ≠ (max R)^2) → (i ≠ (max R)^2) → i.IsPrime) := by
+      intro I hI hm1 _
+      have : I ∈ S' := (Set.Finite.mem_toFinset sFin).mp hI
+      obtain h1|h2 := this
+      exact Ideal.minimalPrimes_isPrime h1
+      contradiction
+
+    have maxinmin : ∃ i ∈ S, (max R) ≤ i := by
+      apply (@Ideal.subset_union_prime (Ideal R) R _ S (λ x => x) ((max R)^2) ((max R)^2) hp (max R)).mp
+      intro x hx
+      obtain xinm2|xnotinm2 := Classical.em (x ∈ (max R) ^ 2)
+      refine Set.mem_iUnion₂.mpr ?_
+      use ((max R)^2)
+      use (Set.Finite.mem_toFinset sFin).mpr (Set.mem_union_right (minimalPrimes R) rfl)
+      exact xinm2
+      have xminP := isMinPrime x hx xnotinm2
+      refine Set.mem_iUnion₂.mpr ?_
+      use Ideal.span {x}
+      use (Set.Finite.mem_toFinset sFin).mpr (Set.mem_union_left {(max R) ^ 2} (isMinPrime x hx xnotinm2))
+      exact Ideal.mem_span_singleton_self x
+
+
+    obtain ⟨P, hP1, hP2⟩ := maxinmin
+
+    have dimNotZero : ringKrullDim R ≠ 0 := by
+      rw[← hR.reg, hn]
+      have : n+1 ≠ 0 := by exact Ne.symm (Nat.zero_ne_add_one n)
+      exact Nat.cast_ne_zero.mpr this
+
+    apply dimNotZero
+
+    clear hn hR_not_Dom isMinPrime dimNotZero hp
+
+    obtain h1|h2 := (Set.Finite.mem_toFinset sFin).mp hP1
+
+    clear hP1 S sFin S'
+
+    rw[← ringKrullDimZero_iff_ringKrullDim_eq_zero]
+    refine Ring.KrullDimLE.mk₀ ?_
+    intro I hI
+    have : I ≤ (max R) := by exact IsLocalRing.le_maximalIdeal (Ideal.IsPrime.ne_top hI)
+    have : I ≤ P := by exact fun ⦃x⦄ a ↦ hP2 (this a)
+    have IP := le_minimalPrimes ‹_› this
+    have mP := le_minimalPrimes ‹_› hP2
+    have Im : I = (max R) := by
+      rw[IP, mP]
+    rw[Im]
+    exact IsLocalRing.maximalIdeal.isMaximal R
+
+    have hm : (max R) ≤ (max R)^2 := by
+      simp_all only [Set.union_singleton, Set.Finite.mem_toFinset, Set.mem_insert_iff, Set.mem_singleton_iff, true_or, S, S']
+
+    have _ : IsNoetherianRing R := by infer_instance
+
+    have mFG := (isNoetherianRing_iff_ideal_fg R).mp ‹_› (max R)
+    have mlem2 : (max R) ≤ (max R) • (max R) := by
+      have : (max R) • (max R) = (max R) * (max R) := rfl
+      rw[this, Eq.symm (pow_two max R)]
+      exact hm
+
+    have mlejac : (max R) ≤ Ideal.jacobson ⊥ := by
+      have : (⊥ : Ideal R) ≠ ⊤ := bot_ne_top
+      rw[IsLocalRing.jacobson_eq_maximalIdeal ⊥ this]
+
+    have mbot := @Submodule.eq_bot_of_le_smul_of_le_jacobson_bot R R _ _ _ (max R) (max R) mFG mlem2 mlejac
+
+    exact ringKrullDim_eq_zero_of_isField (IsLocalRing.isField_iff_maximalIdeal_eq.mpr mbot)
+
+
+-- Regular local rings are domains
+theorem IsRegularLocalRing_IsDomain
+{R : Type*} [CommRing R] [IsRegularLocalRing R] :
+    IsDomain R := by
+  exact IsRegularLocalRing_IsDomain_Induction (Submodule.spanFinrank (max R)) R rfl
+
+
+
+/-
+#check Ideal.exists_minimalPrimes_le
+#check Ideal.iInf_pow_eq_bot_of_localRing
+#check minimalPrimes.finite_of_isNoetherianRing
+#check Ideal.subset_union_prime
+#check Ideal.map_isPrime_of_surjective
+#check Ideal.map_eq_iff_sup_ker_eq_of_surjective
+#check Ideal.comap_map_of_surjective'
+#check Ideal.mk_ker
+#check Ideal.Quotient.mk_surjective
+#check Ideal.comap_injective_of_surjective
+#check Ideal.map_surjective_of_surjective
+#check IsLocalRing.of_surjective
+-/

--- a/RegularLocalRings/Regular_Local_Ring.lean
+++ b/RegularLocalRings/Regular_Local_Ring.lean
@@ -1,5 +1,5 @@
 import Mathlib
-import «LeanMath».LocalRingDimension
+import «RegularLocalRings».LocalRingDimension
 
 
 local notation3:max "max" A => (IsLocalRing.maximalIdeal A)


### PR DESCRIPTION
This PR contains the finished proof that regular local rings are integral domains (modulo two statements in EmbDim.lean). It is in the file Regular_Local_Rings which I added as a new file in case there are things in RegularLocalRings.lean that we still need.

The file KrullsHeightTheorem has three versions of Krull's Height Theorem that are currently being PR'd to Mathlib so those sorries can be ignored.

 The file LocalRingDimension contains a bunch of results on dimension theory for local rings, some of which are used in Regular_Local_Rings and some of independent interest. In particular, it has the result that the dimension of a noetherian local ring is the length of a system of parameters for R. This is then used to show that if x is a non-unit non-zerodivisor, then dim R/x = dim R - 1. It turns out this does not follow from Krull's Principal Ideal theorem. If fact, this is not true for non-local Noetherian rings in general.

Currently, the only unresolved sorries are the two statements in EmbDim.lean.